### PR TITLE
配置順変更

### DIFF
--- a/data/area.json
+++ b/data/area.json
@@ -4,10 +4,10 @@
   { "id": "kemigawahama", "name": "検見川浜" },
   { "id": "kemigawa", "name": "検見川" },
   { "id": "inagekaigan", "name": "稲毛海岸" },
-  { "id": "inage", "name": "稲毛" },
   { "id": "chibaminato", "name": "千葉みなと" },
   { "id": "nishichiba", "name": "西千葉" },
   { "id": "chiba", "name": "千葉" },
+  { "id": "mitsuwadai", "name": "みつわ台" },
   { "id": "makuharihongo", "name": "幕張本郷"},
-  { "id": "mitsuwadai", "name": "みつわ台" }
+  { "id": "inage", "name": "稲毛" }
 ]


### PR DESCRIPTION
エリアの表示順は、なんとなく西からになっているんだけど、オフィシャル情報ではないものしかないエリアは後ろに回しているので、その対応です。